### PR TITLE
chore: Bump version for this library from 0.3.9-dl.0.4 to 0.3.9-dl.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "three-loader",
   "private": false,
-  "version": "0.3.9-dl.0.4",
+  "version": "0.3.9-dl.0.5",
   "description": "Potree loader for ThreeJS, converted and adapted to Typescript.",
   "contributors": [
     "Hugo Campos <hugo.campos@pix4d.com>",


### PR DESCRIPTION
## Scope of PR

- Increment version which we forgot to do in creating the corresponding release.

Once this PR is merged, I will delete the existing release (https://github.com/DataLabs-Japan/three-loader/releases/tag/0.3.9-dl.0.5) and recreate it with the latest commit so that the version in the release and the `package.json` exactly match.
@waisiong-wang-datalabs @khairulashraff 

## Additional note

I tried `yarn install` in a PR of client codes which imports the latest release (https://github.com/DataLabs-Japan/tekkin-app/pull/2167) and then `yarn start`, but got some errors.
The reason was that I imported the previous release `0.3.9-dl.0.4`.
I tried removing `node_modules/` and reinstalling the dependencies again, but got the same error.
It is strange because the CD is functioning for the same PR: https://github.com/DataLabs-Japan/tekkin-app/actions/runs/20135420290

So I suspected that it is caused by the unupdated version in `package.json`.
(A similar issue actually happens when we import internal Python library with `poetry`, a dependency control software for Python)

Let's see whether it works or not :monocle_face: 

## Requested deadline for review

ASAP :fire: 
